### PR TITLE
Add livez, readyz, helthz API

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,22 +1,89 @@
 package main
 
 import (
+	"backend/database"
+	"context"
+	"errors"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 )
 
 func main() {
+	// DB接続
+	db, err := database.NewConnection()
+	if err != nil {
+		panic("Failed to connect to database: " + err.Error())
+	}
+	defer db.Close()
+
+	// Echo インスタンスを作成
+	e := echo.New()
+
+	// ミドルウェア
+	// 起動時のASCIIバナーを消す
+	e.HideBanner = true
+	// /users/ のような末尾スラッシュをリクエスト内で剥がして /users に書き換える
+	e.Pre(middleware.RemoveTrailingSlash())
+	e.Use(
+		middleware.Recover(),
+		middleware.RequestID(),
+		middleware.Logger(),
+		middleware.CORS(),
+	)
+
+	// ポート設定
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
 	}
 
-	e := echo.New()
-	e.GET("/healthz", func(c echo.Context) error {
-		return c.String(http.StatusOK, "ok")
-	})
+	// ---- server with timeouts ----
+	srv := &http.Server{
+		Addr:         ":" + port,
+		Handler:      e,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
 
-	e.Logger.Fatal(e.Start(":" + port))
+	// ---- start & wait for signal ----
+	errCh := make(chan error, 1)
+	go func() { errCh <- e.StartServer(srv) }()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	select {
+	case <-ctx.Done():
+		e.Logger.Info("Server is shutting down...")
+	case err := <-errCh:
+		if !errors.Is(err, http.ErrServerClosed) {
+			e.Logger.Fatal(err)
+		}
+	}
+
+	// ---- graceful shutdown ----
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := e.Shutdown(shutdownCtx); err != nil {
+		e.Logger.Error("graceful shutdown failed, forcing close:", err)
+		if cerr := e.Close(); cerr != nil {
+			e.Logger.Error(cerr)
+		}
+	}
+
+	// DBはここで閉じる（全リクエスト完了後）
+	if derr := db.Close(); derr != nil {
+		e.Logger.Error("db close:", derr)
+	}
+
+	e.Logger.Info("Server stopped")
+
 }

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -1,9 +1,11 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 )
@@ -11,28 +13,60 @@ import (
 func NewConnection() (*sql.DB, error) {
 	host := getEnvWithDefault("DB_HOST", "localhost")
 	port := getEnvWithDefault("DB_PORT", "3306")
-	user := getEnvWithDefault("DB_USER", "sleepfromhistory_user")
-	password := getEnvWithDefault("DB_PASSWORD", "sleepfromhistory_password")
+	user := mustEnv("DB_USER")
+	password := mustEnv("DB_PASSWORD")
 	dbname := getEnvWithDefault("DB_NAME", "sleepfromhistory")
 
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true&charset=utf8mb4&collation=utf8mb4_unicode_ci",
+	// DSN生成 tcp接続
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true&loc=UTC&charset=utf8mb4&collation=utf8mb4_unicode_ci",
 		user, password, host, port, dbname)
 
+	// 接続ハンドル作成
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := db.Ping(); err != nil {
-		return nil, err
+	// 到達性チェック 指数バックオフでPingを繰り返す
+	// backoffを100msで初期化
+	for backoff := 100 * time.Millisecond; ; {
+		// 2秒のタイムアウトを設定
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		err := db.PingContext(ctx)
+		cancel()
+
+		// Ping成功ならループを抜けて終了
+		if err == nil {
+			break
+		}
+		// 一定以上リトライしても成功しなければ諦めてエラーを返す
+		if backoff > 2*time.Second {
+			return nil, err
+		}
+		// 次のPingまで指定時間だけ待つ
+		time.Sleep(backoff)
+		// 待機時間を2倍にして再試行間隔を伸ばす（指数バックオフ）
+		backoff *= 2
 	}
 
 	return db, nil
 }
 
+// 取得した環境変数が空文字ならdefaultValueを返す
 func getEnvWithDefault(key, defaultValue string) string {
+	// 環境変数を取得
 	if value := os.Getenv(key); value != "" {
 		return value
 	}
 	return defaultValue
+}
+
+// 必須の環境変数が未設定なら即座にプロセスを止める
+func mustEnv(k string) string {
+	v := os.Getenv(k)
+	if v == "" {
+		// プログラムを強制的に終了
+		panic("missing required env: " + k)
+	}
+	return v
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -15,4 +15,5 @@ require (
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
+	golang.org/x/time v0.11.0 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -23,3 +23,5 @@ golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
 golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=
+golang.org/x/time v0.11.0 h1:/bpjEDfN9tkoN/ryeYHnv5hcMlc8ncjMcM4XBk5NWV0=
+golang.org/x/time v0.11.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=

--- a/backend/internal/handler/health_handler.go
+++ b/backend/internal/handler/health_handler.go
@@ -1,0 +1,45 @@
+package handler
+
+import (
+	"backend/internal/service"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+type HealthHandler struct {
+	healthSvc service.HealthService
+}
+
+func NewHealthHandler(healthSvc service.HealthService) *HealthHandler {
+	return &HealthHandler{healthSvc: healthSvc}
+}
+
+// プロセスが動いているか
+func (h *HealthHandler) Livez(c echo.Context) error {
+	return c.NoContent(http.StatusOK)
+}
+
+// 依存到達確認
+func (h *HealthHandler) Readyz(c echo.Context) error {
+	// Not Readyのとき
+	if !h.healthSvc.Ready(c.Request().Context()) {
+		// 503 Service Unavailable
+		return c.String(http.StatusServiceUnavailable, "not ready")
+	}
+	// Readyのとき
+	// 200 OK
+	return c.NoContent(http.StatusOK)
+}
+
+// 人間/監視向けの総合診断
+func (h *HealthHandler) Healthz(c echo.Context) error {
+	rep := h.healthSvc.Report(c.Request().Context())
+	// 200 OK
+	code := http.StatusOK
+	if !rep.Ready {
+		// 503 Service Unavailable
+		code = http.StatusServiceUnavailable
+	}
+	return c.JSON(code, rep)
+}

--- a/backend/internal/models/health.go
+++ b/backend/internal/models/health.go
@@ -1,0 +1,9 @@
+package models
+
+type HealthReport struct {
+	Live    bool   `json:"live"`
+	Ready   bool   `json:"ready"`
+	DB      bool   `json:"db"`
+	Version string `json:"version,omitempty"`
+	Time    string `json:"time"`
+}

--- a/backend/internal/repository/health_repository.go
+++ b/backend/internal/repository/health_repository.go
@@ -1,0 +1,26 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+type HealthRepository interface {
+	PingDB(ctx context.Context) error
+}
+
+type healthRepository struct {
+	db *sql.DB
+}
+
+func NewHealthRepository(db *sql.DB) HealthRepository {
+	return &healthRepository{db: db}
+}
+
+// DBへ到達できるか
+func (r *healthRepository) PingDB(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	return r.db.PingContext(ctx)
+}

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -1,0 +1,20 @@
+package routes
+
+import (
+	"backend/internal/handler"
+
+	"github.com/labstack/echo/v4"
+)
+
+func SetupRoutes(
+	// 引数
+	e *echo.Echo,
+	healthHandler *handler.HealthHandler) {
+
+	api := e.Group("/api")
+
+	// ヘルスチェック
+	api.GET("/livez", healthHandler.Livez)
+	api.GET("/readyz", healthHandler.Readyz)
+	api.GET("/healthz", healthHandler.Healthz)
+}

--- a/backend/internal/service/helth_service.go
+++ b/backend/internal/service/helth_service.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"backend/internal/models"
+	"backend/internal/repository"
+	"context"
+	"os"
+	"sync/atomic"
+	"time"
+)
+
+type HealthService interface {
+	Live(ctx context.Context) bool
+	Ready(ctx context.Context) bool
+	Report(ctx context.Context) models.HealthReport
+	MarkReady()
+	MarkNotReady()
+}
+
+type healthService struct {
+	healthRepo repository.HealthRepository
+	// 並行アクセスしても安全に読み書きできるbool
+	readyFlag  atomic.Bool
+	appVersion string
+}
+
+func NewHealthService(healthRepo repository.HealthRepository) HealthService {
+	s := &healthService{
+		healthRepo: healthRepo,
+		appVersion: os.Getenv("APP_VERSION"),
+	}
+	// 起動直後はNotReady
+	s.readyFlag.Store(false)
+	return s
+}
+
+// 準備OK
+func (s *healthService) MarkReady() {
+	s.readyFlag.Store(true)
+}
+
+// 準備NO
+func (s *healthService) MarkNotReady() {
+	s.readyFlag.Store(false)
+}
+
+// プロセスが動いてたらOK
+func (s *healthService) Live(ctx context.Context) bool {
+	return true
+}
+
+// 依存到達確認
+func (s *healthService) Ready(ctx context.Context) bool {
+	if !s.readyFlag.Load() {
+		return false
+	}
+	return s.healthRepo.PingDB(ctx) == nil
+}
+
+// 人間/監視向けの総合診断
+func (s *healthService) Report(ctx context.Context) models.HealthReport {
+	dbOK := s.healthRepo.PingDB(ctx) == nil
+	return models.HealthReport{
+		Live:    true,
+		Ready:   s.readyFlag.Load() && dbOK,
+		DB:      dbOK,
+		Version: s.appVersion,
+		Time:    time.Now().Format(time.RFC3339),
+	}
+}


### PR DESCRIPTION
# 概要
以下のAPIを作成
- GET /livez：プロセスの生存確認（liveness）
  サーバが起動していれば200を返す。外部依存にはアクセスしない。

- GET /readyz：依存到達確認（readiness）
  DB疎通などを確認し、問題があれば503を返す。

- GET /healthz：総合診断（health report）
  稼働状態、DB到達、アプリバージョン、時刻などをJSONで返す。監視・人間確認用。

# 動作確認
## GET /livez
<img width="908" height="628" alt="image" src="https://github.com/user-attachments/assets/000fbf23-2aca-41d3-8c0f-69234148b222" />

## GET /readyz
### 成功
<img width="911" height="632" alt="image" src="https://github.com/user-attachments/assets/b5eeaf9b-ba8b-4d67-b9e1-078ef6b236d6" />

### 失敗
<img width="905" height="656" alt="image" src="https://github.com/user-attachments/assets/a7cd800d-6706-49a6-a5ac-d708859d0c02" />

## GET /healthz
### 成功
<img width="908" height="669" alt="image" src="https://github.com/user-attachments/assets/08ed6401-f865-4162-99d3-284d3809d0bc" />

### 失敗
<img width="910" height="665" alt="image" src="https://github.com/user-attachments/assets/c8a4d835-3189-4d10-afd3-07165457bab5" />
